### PR TITLE
feat(ci): per-module coverage gates toevoegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,29 +49,29 @@ jobs:
         run: |
           pytest --maxfail=1 --disable-warnings --cov=src --cov-report=xml:coverage.xml --cov-report=term-missing
 
-      - name: Coverage gate: strategy.py ≥ 90%
+      - name: "Coverage gate: strategy.py ≥ 90%"
         run: coverage report --include=src/strategy.py --fail-under=90 -m
 
-      - name: Coverage gate: run_once.py ≥ 80%
+      - name: "Coverage gate: run_once.py ≥ 80%"
         run: coverage report --include=src/run_once.py --fail-under=80 -m
 
-      - name: Coverage gate: executor.py ≥ 80%
+      - name: "Coverage gate: executor.py ≥ 80%"
         run: coverage report --include=src/executor.py --fail-under=80 -m
 
-      - name: Coverage gate: kucoin_client.py ≥ 80%
+      - name: "Coverage gate: kucoin_client.py ≥ 80%"
         run: coverage report --include=src/client/kucoin_client.py --fail-under=80 -m
 
-      - name: Coverage gate: ws_client & ws_replay ≥ 80%
+      - name: "Coverage gate: ws_client & ws_replay ≥ 80%"
         run: |
           coverage report --include=src/ws_client.py --fail-under=80 -m
           coverage report --include=src/ws_replay.py --fail-under=80 -m
 
-      - name: Coverage gate: parser & models ≥ 80%
+      - name: "Coverage gate: parser & models ≥ 80%"
         run: |
           coverage report --include=src/parser/* --fail-under=80 -m
           coverage report --include=src/models/* --fail-under=80 -m
 
-      - name: Coverage gate: orchestrator.py ≥ 80%
+      - name: "Coverage gate: orchestrator.py ≥ 80%"
         run: coverage report --include=src/orchestrator.py --fail-under=80 -m
 
       - name: Full coverage report

--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ from src.kucoin_fetcher import fetch_klines
 df = fetch_klines("THETA-USDT", "5m", start_ts=1620000000, limit=100)
 print(df.head())
 ```
+


### PR DESCRIPTION
Voegt in de GitHub Actions-workflow per-module coverage-gates toe zodat bij iedere push en pull request gewaarborgd wordt dat kritische onderdelen minimaal voldoende getest zijn:
	•	strategy.py ≥ 90%
	•	run_once.py ≥ 80%
	•	executor.py ≥ 80%
	•	src/client/kucoin_client.py ≥ 80%
	•	ws_client.py & ws_replay.py ≥ 80%
	•	parser/ & models/ ≥ 80%
	•	orchestrator.py ≥ 80%

Daarnaast wordt na deze gates een totale coverage-rapportage (“Full coverage report”) gedraaid. Falen van een gate blokkeert de build, met heldere feedback in de CI-logs.

Hoe te reviewen:
	1.	Bekijk .github/workflows/ci.yml voor de nieuwe stappen met coverage report --fail-under.
	2.	Controleer in de volgende run of alle gates groen doorlopen.
	3.	Zie in docs/CI_Coverage_Gates.md voor uitleg over hoe drempels aan te passen of toe te voegen.